### PR TITLE
Nvim

### DIFF
--- a/home-manager/modules/neovim.nix
+++ b/home-manager/modules/neovim.nix
@@ -5,7 +5,7 @@
 }:
 
 let
-  nvimConfigPath = "/home/aki/neovim-config/nvim";
+  nvimConfigPath = "${config.home.homeDirectory}/neovim-config/nvim";
 in
 {
 


### PR DESCRIPTION
Previously, I manually created a symbolic link from `$HOME/neovim-config/nvim` to `$HOME/.config/nvim`, but I've now set up home-manager to create it automatically.