### PR TITLE
Manage SKK-JISYO.L with Nix

### DIFF
--- a/home-manager/modules/neovim.nix
+++ b/home-manager/modules/neovim.nix
@@ -21,12 +21,14 @@ in
     pkgs.libskk
   ];
 
-  home.sessionVariables = {
-    SKK_JISYO_L_PATH = traceSkkDictPath;
-  };
-
   programs.neovim = {
     enable = true;
+
+    extraWrapperArgs = [
+      "--set"
+      "SKK_JISYO_L_PATH"
+      traceSkkDictPath
+    ];
 
     extraPackages = [
       # Language Servers


### PR DESCRIPTION
Previously, `SKK-JISYO.L` was managed by the Arch Linux package `skk-jisyo`, but the configuration has been changed to use the `SKK-JISYO.L` included in the `libskk` package from nixpkgs.