### PR TITLE
fix/neovim-config-link: revert to `mkOutOfStoreSymlink` and add `prog…

### DIFF
--- a/modules/neovim.nix
+++ b/modules/neovim.nix
@@ -32,7 +32,7 @@ in
   home.file.".config/nvim" =
     if builtins.pathExists "${nvimConfigPath}" then
       {
-        source = "${nvimConfigPath}";
+        source = config.lib.file.mkOutOfStoreSymlink "${nvimConfigPath}";
         recursive = true;
       }
     else
@@ -45,6 +45,7 @@ in
   programs.neovim = {
     enable = true;
     viAlias = true;
+    sideloadInitLua = true;
 
     extraWrapperArgs = [
       "--set"


### PR DESCRIPTION
I changed to ˋhome.file.config.nvimˋ= . But this config style needs to ˋrebuild switchˋ when Neovim config is changed.