### PR TITLE
Service/virtualisation

### DIFF
--- a/hosts/nixosSwayDesktop/default.nix
+++ b/hosts/nixosSwayDesktop/default.nix
@@ -53,7 +53,10 @@ nixpkgs.lib.nixosSystem {
         (import "${flakeRoot}/nixos/gui-app" { inherit pkgs pgopher userName; })
         (import "${flakeRoot}/nixos/nix-ld" { inherit pkgs; })
         (import "${flakeRoot}/nixos/locale" { inherit pkgs; })
-        (import "${flakeRoot}/nixos/virtualisation" { inherit pkgs containerd-shim-wasmtime-v1; })
+        (import "${flakeRoot}/nixos/virtualisation" {
+          inherit pkgs containerd-shim-wasmtime-v1;
+          isAutoStart = true;
+        })
         # Include the results of the hardware scan.
         ./hardware-configuration.nix
         home-manager.nixosModules.home-manager

--- a/nixos/virtualisation/default.nix
+++ b/nixos/virtualisation/default.nix
@@ -1,4 +1,12 @@
-{ pkgs, containerd-shim-wasmtime-v1 }:
+{
+  pkgs,
+  containerd-shim-wasmtime-v1,
+  isAutoStart ? false,
+  ...
+}:
+let
+  serviceTarget = if isAutoStart then [ "multi-user.target" ] else pkgs.lib.mkForce [ ];
+in
 {
 
   virtualisation = {
@@ -39,14 +47,14 @@
     buildah
   ];
 
-  systemd.services.docker.wantedBy = pkgs.lib.mkForce [ ];
+  systemd.services.docker.wantedBy = serviceTarget;
   systemd.services.containerd = {
-    wantedBy = pkgs.lib.mkForce [ ];
+    wantedBy = serviceTarget;
     path = [
       containerd-shim-wasmtime-v1.packages.x86_64-linux.default
     ];
   };
   # for libvirt + QEMU
-  systemd.services.libvirtd.wantedBy = pkgs.lib.mkForce [ ];
-  systemd.services.virtqemud.wantedBy = pkgs.lib.mkForce [ ];
+  systemd.services.libvirtd.wantedBy = serviceTarget;
+  systemd.services.virtqemud.wantedBy = serviceTarget;
 }

--- a/nixos/virtualisation/default.nix
+++ b/nixos/virtualisation/default.nix
@@ -46,4 +46,7 @@
       containerd-shim-wasmtime-v1.packages.x86_64-linux.default
     ];
   };
+  # for libvirt + QEMU
+  systemd.services.libvirtd.wantedBy = pkgs.lib.mkForce [ ];
+  systemd.services.virtqemud.wantedBy = pkgs.lib.mkForce [ ];
 }

--- a/nixos/virtualisation/default.nix
+++ b/nixos/virtualisation/default.nix
@@ -47,14 +47,20 @@ in
     buildah
   ];
 
-  systemd.services.docker.wantedBy = serviceTarget;
-  systemd.services.containerd = {
-    wantedBy = serviceTarget;
-    path = [
-      containerd-shim-wasmtime-v1.packages.x86_64-linux.default
-    ];
+  systemd.services = {
+    # Docker
+    docker.wantedBy = serviceTarget;
+
+    # containerd
+    containerd = {
+      wantedBy = serviceTarget;
+      path = [
+        containerd-shim-wasmtime-v1.packages.x86_64-linux.default
+      ];
+    };
+
+    # for libvirt + QEMU
+    libvirtd.wantedBy = serviceTarget;
+    virtqemud.wantedBy = serviceTarget;
   };
-  # for libvirt + QEMU
-  systemd.services.libvirtd.wantedBy = serviceTarget;
-  systemd.services.virtqemud.wantedBy = serviceTarget;
 }

--- a/nixos/virtualisation/default.nix
+++ b/nixos/virtualisation/default.nix
@@ -39,7 +39,9 @@
     buildah
   ];
 
+  systemd.services.docker.wantedBy = pkgs.lib.mkForce [ ];
   systemd.services.containerd = {
+    wantedBy = pkgs.lib.mkForce [ ];
     path = [
       containerd-shim-wasmtime-v1.packages.x86_64-linux.default
     ];


### PR DESCRIPTION
Following the instructions below, I configured `Docker`, `nerdctl`, and `libvirt` to start only when needed by enabling just the *.socket files without setting them to autostart.
- ref
   - [How to prevent rootless Docker in Nix OS from autostarting](https://medium.com/@burlakovv.ivan/how-to-prevent-rootless-docker-in-nix-os-to-autostart-eac7bc756bdd)
   -  [Disable a systemd service while having it in NixOS’s conf](https://discourse.nixos.org/t/disable-a-systemd-service-while-having-it-in-nixoss-conf/12732)

Additionally, I configured it so that autostart is enabled when `isAutoStart = true` is specified, and we enabled this in `nixOSDesktop`.
