### PR TITLE
Fix/delete iwd

### DIFF
--- a/hosts/nixosSwayLaptop/default.nix
+++ b/hosts/nixosSwayLaptop/default.nix
@@ -155,7 +155,7 @@ nixpkgs.lib.nixosSystem {
 
       networking.hostName = "nix"; # Define your hostname.
       networking.networkmanager.enable = true; # Easiest to use and most distros use this by default.
-      networking.networkmanager.wifi.backend = "iwd"; # Enables wireless support via iwd.
+      #networking.networkmanager.wifi.backend = "iwd"; # Enables wireless support via iwd.
       # config for iwd
       networking.wireless.iwd.settings = {
         Network = {

--- a/hosts/nixosSwayLaptop/default.nix
+++ b/hosts/nixosSwayLaptop/default.nix
@@ -155,16 +155,20 @@ nixpkgs.lib.nixosSystem {
 
       networking.hostName = "nix"; # Define your hostname.
       networking.networkmanager.enable = true; # Easiest to use and most distros use this by default.
-      #networking.networkmanager.wifi.backend = "iwd"; # Enables wireless support via iwd.
-      # config for iwd
-      networking.wireless.iwd.settings = {
-        Network = {
-          EnableIPv6 = true;
-        };
-        Settings = {
-          AutoConnect = true;
-        };
-      };
+      # tempolay remove config for iwd
+      /*
+          networking.networkmanager.wifi.backend = "iwd"; # Enables wireless support via iwd.
+          # config for iwd
+          networking.wireless.iwd.settings = {
+            Network = {
+              EnableIPv6 = true;
+            };
+            Settings = {
+              AutoConnect = true;
+            };
+          };
+        **
+      */
       # firewall: deny all in-comming
       networking.firewall.enable = true;
       # enable bluetooth


### PR DESCRIPTION
tempolay remove config for `iwd`, because wifi access point config  saved in  `/var/lib/iwd` was cleared by reboot.