### PR TITLE
feat/systemd-sway-kanshi: I made kanshi depend on `sway-session.targe…

### DIFF
--- a/hosts/nixosSwayLaptop/default.nix
+++ b/hosts/nixosSwayLaptop/default.nix
@@ -106,8 +106,7 @@ nixpkgs.lib.nixosSystem {
                   # start libinput-gestures
                   exec libinput-gestures
 
-                  # give Sway a little time to startup before starting kanshi.
-                  exec sleep 5; systemctl --user start kanshi.service
+                  exec_always "systemctl --user start sway-session.target"
                 '';
               };
               # waybar

--- a/nixos/kanshi/default.nix
+++ b/nixos/kanshi/default.nix
@@ -11,5 +11,8 @@
       Type = "simple";
       ExecStart = "${pkgs.kanshi}/bin/kanshi";
     };
+
+    # Install
+    wantedBy = [ "sway-session.target" ];
   };
 }


### PR DESCRIPTION
Since `sway-session.target` is already enabled when sway is installed, I configured `kanshi` to depend on `sway-session.target` so that it would manage the `kanshi` daemon.